### PR TITLE
goal_repetitions and goal_time can now be customised

### DIFF
--- a/backend/special_effects/delayed_effect.py
+++ b/backend/special_effects/delayed_effect.py
@@ -87,6 +87,7 @@ class DelayedEffect(SpecialEffect):
         new_special_effects = [se.apply_sfx_on_arg(arg, param_arg_dict) for se in self.special_effects]
         return DelayedEffect(self.param, new_effects, new_special_effects,
                              self.default_goal_time, arg, config_key=self.config_key)
+    
     def _resolve_goal_time_if_needed(self, state):
         """
         Resolves the goal time for the effect if it has not already been

--- a/backend/special_effects/delayed_effect.py
+++ b/backend/special_effects/delayed_effect.py
@@ -1,4 +1,5 @@
 from backend.special_effect import SpecialEffect
+from utils.robotouille_utils import trim_item_ID
 
 class DelayedEffect(SpecialEffect):
     """
@@ -8,7 +9,7 @@ class DelayedEffect(SpecialEffect):
     of time has passed.
     """
 
-    def __init__(self, param, effects, special_effects, goal_time=4, arg=None):
+    def __init__(self, param, effects, special_effects, default_goal_time=4, arg=None, config_key=None):
         """
         Initializes a delayed effect.
 
@@ -18,14 +19,19 @@ class DelayedEffect(SpecialEffect):
                 represented by a dictionary of predicates and bools.
             special_effects (List[SpecialEffect]): The nested special effects of
                 the action.
-            goal_time (int): The number of time steps that must pass before the
-                effect is applied.
+            sfx_config (Dict[str, Any]):
+                The environment configuration for the specific special effect.
+            default_goal_time (int): The time it takes for the effect to be applied.
             arg (Object): The object that the effect is applied to. If the
                 special effect is not applied to an object, arg is None.
+            config_key (str): The key to use when looking up the goal time in the config.
         """
         super().__init__(param, effects, special_effects, False, arg)
-        self.goal_time = goal_time
+        
+        self.default_goal_time = default_goal_time
+        self.goal_time = None
         self.current_time = 0
+        self.config_key = config_key
 
     def __eq__(self, other):
         """
@@ -39,7 +45,8 @@ class DelayedEffect(SpecialEffect):
         """
         return self.param == other.param and self.effects == other.effects \
             and self.special_effects == other.special_effects \
-                and self.goal_time == other.goal_time and self.arg == other.arg
+                and self.default_goal_time == other.default_goal_time and self.arg == other.arg \
+                    and self.config_key == other.config_key
     
     def __hash__(self):
         """
@@ -49,7 +56,7 @@ class DelayedEffect(SpecialEffect):
             hash (int): The hash of the delayed effect.
         """
         return hash((self.param, tuple(self.effects), tuple(self.special_effects), 
-                     self.completed, self.current_time, self.arg))
+                     self.completed, self.current_time, self.arg, self.config_key))
     
     def __repr__(self):
         """
@@ -77,10 +84,27 @@ class DelayedEffect(SpecialEffect):
         new_effects = {}
         for effect, value in self.effects.items():
             new_effects[effect.replace_pred_params_with_args(param_arg_dict)] = value
-        new_special_effects = []
-        for special_effect in self.special_effects:
-            new_special_effects.append(special_effect.apply_sfx_on_arg(arg, param_arg_dict))
-        return DelayedEffect(self.param, new_effects, new_special_effects, self.goal_time, arg)
+        new_special_effects = [se.apply_sfx_on_arg(arg, param_arg_dict) for se in self.special_effects]
+        return DelayedEffect(self.param, new_effects, new_special_effects,
+                             self.default_goal_time, arg, config_key=self.config_key)
+    def _resolve_goal_time_if_needed(self, state):
+        """
+        Resolves the goal time for the effect if it has not already been
+        resolved.
+
+        Args:
+            state (State): The current state. 
+        """
+        if self.goal_time is not None:
+            return
+        if self.arg is None:
+            self.goal_time = self.default_goal_time
+            return
+        base_name, _ = trim_item_ID(self.arg.name)
+        table = state.config.get(self.config_key, {}) if self.config_key else {}
+        raw = table.get(base_name, table.get("default", self.default_goal_time))
+        self.goal_time = max(1, raw)
+
 
     def increment_time(self):
         """
@@ -98,6 +122,7 @@ class DelayedEffect(SpecialEffect):
             performed.
         """
         if active or self.completed: return
+        self._resolve_goal_time_if_needed(state)
         self.increment_time()
         if self.current_time == self.goal_time:
             for effect, value in self.effects.items():

--- a/backend/special_effects/repetitive_effect.py
+++ b/backend/special_effects/repetitive_effect.py
@@ -81,7 +81,7 @@ class RepetitiveEffect(SpecialEffect):
             new_effects = {}
             for effect, value in self.effects.items():
                 new_effects[effect.replace_pred_params_with_args(param_arg_dict)] = value
-            new_special_effects = [se.apply_sfx_on_arg(arg, param_arg_dict) for se in self.special_effects]
+            new_special_effects = [sfx.apply_sfx_on_arg(arg, param_arg_dict) for sfx in self.special_effects]
             return RepetitiveEffect(self.param, new_effects, new_special_effects,
                                     self.default_goal_repetitions, arg, config_key=self.config_key)
     

--- a/backend/special_effects/repetitive_effect.py
+++ b/backend/special_effects/repetitive_effect.py
@@ -1,4 +1,5 @@
 from backend.special_effect import SpecialEffect
+from utils.robotouille_utils import trim_item_ID
 
 class RepetitiveEffect(SpecialEffect):
     """
@@ -8,7 +9,7 @@ class RepetitiveEffect(SpecialEffect):
     been performed a certain number of times.
     """
     
-    def __init__(self, param, effects, special_effects, goal_repetitions=3, arg=None):
+    def __init__(self, param, effects, special_effects, default_goal_repetitions=3, arg=None, config_key=None):
         """
         Initializes a repetitive effect.
 
@@ -18,14 +19,16 @@ class RepetitiveEffect(SpecialEffect):
                 represented by a dictionary of predicates and bools.
             special_effects (List[SpecialEffect]): The nested special effects of
                 the action.
-            goal_repetitions (int): The number of times the action must be 
-                performed before the effect is applied.
+            default_goal_repetitions (int): The number of times the action must be 
+                performed before the effect is applied by default.
             arg (Object): The object that the effect is applied to. If the
                 special effect is not applied to an object, arg is None.
         """
         super().__init__(param, effects, special_effects, False, arg)
-        self.goal_repetitions = goal_repetitions
+        self.default_goal_repetitions = default_goal_repetitions
+        self.goal_repetitions = None # This is resolved locally when applying the effect to an argument
         self.current_repetitions = 0
+        self.config_key = config_key
 
     def __eq__(self, other):
         """
@@ -39,8 +42,8 @@ class RepetitiveEffect(SpecialEffect):
         """
         return self.param == other.param and self.effects == other.effects \
             and self.special_effects == other.special_effects \
-                and self.goal_repetitions == other.goal_repetitions \
-                    and self.arg == other.arg
+                and self.default_goal_repetitions == other.default_goal_repetitions \
+                    and self.arg == other.arg and self.config_key == other.config_key
     
     def __hash__(self):
         """
@@ -50,7 +53,7 @@ class RepetitiveEffect(SpecialEffect):
             hash (int): The hash of the repetitive effect.
         """
         return hash((self.param, tuple(self.effects), tuple(self.special_effects), 
-                     self.completed, self.current_repetitions, self.arg))
+                     self.completed, self.current_repetitions, self.arg, self.config_key))
     
     def __repr__(self):
         """
@@ -78,11 +81,32 @@ class RepetitiveEffect(SpecialEffect):
             new_effects = {}
             for effect, value in self.effects.items():
                 new_effects[effect.replace_pred_params_with_args(param_arg_dict)] = value
-            new_special_effects = []
-            for special_effect in self.special_effects:
-                new_special_effects.append(special_effect.apply_sfx_on_arg(arg, param_arg_dict))
-            return RepetitiveEffect(self.param, new_effects, new_special_effects, self.goal_repetitions, arg)
+            new_special_effects = [se.apply_sfx_on_arg(arg, param_arg_dict) for se in self.special_effects]
+            return RepetitiveEffect(self.param, new_effects, new_special_effects,
+                                    self.default_goal_repetitions, arg, config_key=self.config_key)
+    
+    def _resolve_goal_repetitions_if_needed(self, state):
+        """
+        Resolves the goal repetitions for the effect if it has not already been
+        resolved.
 
+        Args:
+            state (State): The current state.
+        """
+        if self.goal_repetitions is not None:
+            return
+        
+        # If there is no bound arg, just use default
+        if self.arg is None:
+            self.goal_repetitions = self.default_goal_repetitions
+            return
+
+        base_name, _ = trim_item_ID(self.arg.name)
+        # Read from config
+        table = state.config.get(self.config_key, {}) if self.config_key else {}
+        raw = table.get(base_name, table.get("default", self.default_goal_repetitions))
+        self.goal_repetitions = max(1, raw)
+    
     def increment_repetitions(self):
         """
         Increments the number of times the action has been performed.
@@ -99,6 +123,7 @@ class RepetitiveEffect(SpecialEffect):
             performed.
         """
         if not active or self.completed: return
+        self._resolve_goal_repetitions_if_needed(state)
         self.increment_repetitions()
         if self.current_repetitions == self.goal_repetitions:
             for effect, value in self.effects.items():

--- a/backend/state.py
+++ b/backend/state.py
@@ -22,6 +22,7 @@ class State(object):
         self.actions = {}
         self.goal = []
         self.special_effects = []
+        self.config = {}
 
     def _build_object_dictionary(self, domain, objects):
         """
@@ -135,7 +136,7 @@ class State(object):
         """
         return [obj for obj in self.objects if obj.object_type == "player"]
 
-    def initialize(self, domain, objects, true_predicates, all_goals, goal_description, special_effects=[]):
+    def initialize(self, domain, objects, true_predicates, all_goals, goal_description, special_effects=[], config = None):
         """
         Initializes a state object.
 
@@ -160,6 +161,8 @@ class State(object):
                 The natural language description of the goal.
             special_effects (List[Special_effects]):
                 The special effects that are active in the state.
+            config (Dict[str, Any]):
+                The configuration for the state.
 
         Returns:
             state (State): The initialized state.
@@ -191,6 +194,7 @@ class State(object):
         self.goal = all_goals
         self.goal_description = goal_description
         self.special_effects = special_effects
+        self.config = config or {}
 
         return self
         

--- a/backend/tests/test_envs.py
+++ b/backend/tests/test_envs.py
@@ -58,5 +58,5 @@ for test_group, tests in ALL_TESTS.items():
     print(f"Running {test_group} tests")
     for test in tests:
         print(f"Running {test} test")
-        subprocess.run(f"python main.py ++game.environment_name {test}", shell=True)
+        subprocess.run(f"python main.py ++game.environment_name={test}", shell=True)
     print(f"Finished running {test_group} tests\n")

--- a/domain/domain_builder.py
+++ b/domain/domain_builder.py
@@ -89,10 +89,15 @@ def _build_special_effects(defn, param_objs, predicate_dict):
             special_effect["fx"], param_objs, predicate_dict)
         nested_sfx = _build_special_effects(special_effect["sfx"], param_objs, predicate_dict)
         if special_effect["type"] == "delayed":
-            # TODO (lsuyean): The values for goal repetitions/time should be decided by the problem json
-            sfx = DelayedEffect(param_obj, effects, nested_sfx)
+            goal_time = special_effect.get("goal_time", 4)
+            if goal_time < 1:
+                goal_time = 1
+            sfx = DelayedEffect(param_obj, effects, nested_sfx, goal_time=goal_time)
         elif special_effect["type"] == "repetitive":
-            sfx = RepetitiveEffect(param_obj, effects, nested_sfx)
+            goal_repetitions = special_effect.get("goal_repetitions", 3)
+            if goal_repetitions < 1:
+                goal_repetitions = 1
+            sfx = RepetitiveEffect(param_obj, effects, nested_sfx, goal_repetitions=goal_repetitions)
         elif special_effect["type"] == "conditional":
             conditions = _build_pred_list(
                 special_effect["conditions"], param_objs, predicate_dict)

--- a/domain/domain_builder.py
+++ b/domain/domain_builder.py
@@ -8,6 +8,13 @@ from backend.special_effects.conditional_effect import ConditionalEffect
 from backend.special_effects.creation_effect import CreationEffect
 from backend.special_effects.deletion_effect import DeletionEffect
 
+sfx_config_dict = {
+    "cut": "num_cuts",
+    "cook": "cook_time",
+    "fry": "fry_time",
+    "boil": "boil_time",
+    "fill": "fill_time"
+}
 
 def _build_predicate_defs(domain_json):
     """
@@ -64,7 +71,7 @@ def _build_pred_list(defn, param_objs, predicate_dict):
 
     return precons_or_effects
 
-def _build_special_effects(defn, param_objs, predicate_dict):
+def _build_special_effects(defn, param_objs, predicate_dict, sfx_config_key):
     """
     This function builds special effects. 
 
@@ -73,6 +80,8 @@ def _build_special_effects(defn, param_objs, predicate_dict):
         param_objs (Dictionary[str, Object]): A dictionary whose keys are
             parameter names and the values are placeholder objects. 
         predicate_dict (Dictionary[str, Predicate]): The predicate dictionary.
+        sfx_config_key (str):
+            The key to use when looking up the special effect configuration.
 
     Returns:
         special_effects (List[SpecialEffect]): The special effects of the action.
@@ -87,17 +96,11 @@ def _build_special_effects(defn, param_objs, predicate_dict):
         param_obj = param_objs[param_name]
         effects = _build_pred_list(
             special_effect["fx"], param_objs, predicate_dict)
-        nested_sfx = _build_special_effects(special_effect["sfx"], param_objs, predicate_dict)
+        nested_sfx = _build_special_effects(special_effect["sfx"], param_objs, predicate_dict, sfx_config_key)
         if special_effect["type"] == "delayed":
-            goal_time = special_effect.get("goal_time", 4)
-            if goal_time < 1:
-                goal_time = 1
-            sfx = DelayedEffect(param_obj, effects, nested_sfx, goal_time=goal_time)
+            sfx = DelayedEffect(param_obj, effects, nested_sfx, config_key=sfx_config_key)
         elif special_effect["type"] == "repetitive":
-            goal_repetitions = special_effect.get("goal_repetitions", 3)
-            if goal_repetitions < 1:
-                goal_repetitions = 1
-            sfx = RepetitiveEffect(param_obj, effects, nested_sfx, goal_repetitions=goal_repetitions)
+            sfx = RepetitiveEffect(param_obj, effects, nested_sfx, config_key=sfx_config_key)
         elif special_effect["type"] == "conditional":
             conditions = _build_pred_list(
                 special_effect["conditions"], param_objs, predicate_dict)
@@ -115,7 +118,7 @@ def _build_special_effects(defn, param_objs, predicate_dict):
 
     return special_effects
 
-def _build_action_defs(domain_json, predicate_defs):
+def _build_action_defs(domain_json, predicate_defs, env_config):
     """
     This function builds action definitions from a JSON input.
 
@@ -124,6 +127,8 @@ def _build_action_defs(domain_json, predicate_defs):
             The JSON representation of the domain.
         predicate_defs (List[Predicate]):
             The predicate definitions.
+        env_config (Dict[str, Any]):
+            The environment configuration for special effects.
 
     Returns:
         action_defs (List[Action]):
@@ -141,22 +146,24 @@ def _build_action_defs(domain_json, predicate_defs):
             action["precons"], param_objs, predicate_dict)
         immediate_effects = _build_pred_list(
             action["immediate_fx"], param_objs, predicate_dict)
+        sfx_config_key = sfx_config_dict.get(name, None)
         special_effects = _build_special_effects(
-            action["sfx"], param_objs, predicate_dict)
+            action["sfx"], param_objs, predicate_dict, sfx_config_key)
         language_description = action["language_description"]
         action_def = Action(name, precons, immediate_effects, special_effects, language_description=language_description)
         action_defs.append(action_def)
 
     return action_defs
         
-def build_domain(domain_json):
+def build_domain(domain_json, env_config={}):
     """
     This function builds a domain object from a JSON input.
 
     Args:
         domain_json (Dict[str, Any]):
             The JSON representation of the domain.
-
+        env_config (Dict[str, Any]):
+            The environment configuration for special effects. 
     Returns:
         domain (Domain): The domain object.
     """
@@ -166,7 +173,7 @@ def build_domain(domain_json):
 
     predicate_defs = _build_predicate_defs(domain_json)
 
-    action_defs = _build_action_defs(domain_json, predicate_defs)
+    action_defs = _build_action_defs(domain_json, predicate_defs, env_config)
 
     domain = Domain().initialize(name, object_types, predicate_defs, action_defs)
 

--- a/domain/robotouille.json
+++ b/domain/robotouille.json
@@ -616,6 +616,7 @@
                         {
                             "type": "delayed",
                             "param": "i1",
+                            "goal_time": 4, 
                             "fx": [
                                 {
                                     "predicate": "iscooked",
@@ -674,6 +675,7 @@
                 {
                     "type": "repetitive",
                     "param": "i1",
+                    "goal_repetitions": 3,
                     "fx": [
                         {
                             "predicate": "iscut",
@@ -761,6 +763,7 @@
                         {
                             "type": "delayed",
                             "param": "i1",
+                            "goal_time": 4, 
                             "fx": [
                                 {
                                     "predicate": "isfried",
@@ -826,6 +829,7 @@
                         {
                             "type": "delayed",
                             "param": "c1",
+                            "goal_time": 4,
                             "fx": [],
                             "sfx": [
                                 {
@@ -918,6 +922,7 @@
                         {
                             "type": "delayed",
                             "param": "m1",
+                            "goal_time": 4,
                             "fx": [
                                 {
                                     "predicate": "isboiling",

--- a/domain/robotouille.json
+++ b/domain/robotouille.json
@@ -616,7 +616,6 @@
                         {
                             "type": "delayed",
                             "param": "i1",
-                            "goal_time": 4, 
                             "fx": [
                                 {
                                     "predicate": "iscooked",
@@ -675,7 +674,6 @@
                 {
                     "type": "repetitive",
                     "param": "i1",
-                    "goal_repetitions": 3,
                     "fx": [
                         {
                             "predicate": "iscut",
@@ -763,7 +761,6 @@
                         {
                             "type": "delayed",
                             "param": "i1",
-                            "goal_time": 4, 
                             "fx": [
                                 {
                                     "predicate": "isfried",
@@ -829,7 +826,6 @@
                         {
                             "type": "delayed",
                             "param": "c1",
-                            "goal_time": 4,
                             "fx": [],
                             "sfx": [
                                 {
@@ -922,7 +918,6 @@
                         {
                             "type": "delayed",
                             "param": "m1",
-                            "goal_time": 4,
                             "fx": [
                                 {
                                     "predicate": "isboiling",

--- a/robotouille/env.py
+++ b/robotouille/env.py
@@ -337,7 +337,8 @@ def build_state(domain_json, environment_json):
     Returns:
         state (State): The state.
     """
-    domain = build_domain(domain_json)
+    env_config = environment_json.get("config", {})
+    domain = build_domain(domain_json, env_config)
 
     entity_fields = domain.get_entity_fields()
 
@@ -355,7 +356,7 @@ def build_state(domain_json, environment_json):
     goal = build_goal(domain_json, environment_json)
     goal_description = environment_json["goal_description"]
 
-    state = State().initialize(domain, objects, true_predicates, goal, goal_description)
+    state = State().initialize(domain, objects, true_predicates, goal, goal_description, config=env_config)
 
     return state
 


### PR DESCRIPTION
## Overview

Goal time for delayed effect, and goal repetitions for repetitive effect can now be edited in the env json. Added checks to ensure the values are at least one. 

## Test Coverage

Tested environments, changed values in the env json

## Related PRs or Issues (delete if not applicable)

Issue #70 